### PR TITLE
Changed before and after hooks to be All instead of Each

### DIFF
--- a/it/base/BaseISpec.scala
+++ b/it/base/BaseISpec.scala
@@ -18,7 +18,7 @@ package base
 
 import common.SessionKeys
 import config.AppConfig
-import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.data.Form
 import play.api.http.HeaderNames
@@ -33,7 +33,7 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Awaitable}
 
 trait BaseISpec extends WordSpec with WireMockHelper with Matchers with
-  BeforeAndAfterEach with GuiceOneServerPerSuite {
+  BeforeAndAfterAll with GuiceOneServerPerSuite {
 
   def servicesConfig: Map[String, String] = Map(
     "play.filters.csrf.header.bypassHeaders.Csrf-Token" -> "nocheck",
@@ -58,14 +58,14 @@ trait BaseISpec extends WordSpec with WireMockHelper with Matchers with
   lazy val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
   val appRouteContext: String = "/vat-through-software/submit-vat-return"
 
-  override def beforeEach(): Unit = {
-    super.beforeEach()
+  override def beforeAll(): Unit = {
+    super.beforeAll()
     startServer()
   }
 
-  override def afterEach(): Unit = {
+  override def afterAll(): Unit = {
     stopServer()
-    super.afterEach()
+    super.afterAll()
   }
 
   def await[T](awaitable: Awaitable[T]): T = Await.result(awaitable, Duration.Inf)


### PR DESCRIPTION
Should solve intermittent build failures due to wiremock closing too quickly

# Pull Request Checklist
* [x] Branch is rebased with master
* [ ] Added Unit Tests for changed functionality
* [x] Ran `sbt clean compile coverage test it:test coverageReport`, all tests pass and coverage meets minimum
* [x] Checked libraries are up to date with `sbt validate`. (If applicable) library updates are done in a separate, single commit
* [ ] Ran [submit-vat-return-acceptance-tests](https://github.com/hmrc/submit-vat-return-acceptance-tests) (see README of repo)
* [ ] Ran [vat-returns-performance-tests](https://github.com/hmrc/vat-returns-performance-tests) (see README of repo)
* [ ] (If applicable) raised app-config-* PRs
* [ ] (If applicable) ran Wave test for changes to views
* [ ] (If applicable) added Integration Tests
