### PR TITLE
[BTAT-6415] Created utils to capture, encode and get checksum of payload

### DIFF
--- a/app/controllers/ConfirmSubmissionController.scala
+++ b/app/controllers/ConfirmSubmissionController.scala
@@ -34,6 +34,7 @@ import play.api.mvc._
 import play.twirl.api.Html
 import services.{DateService, VatReturnsService, VatSubscriptionService}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import utils.HashUtil
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
@@ -124,6 +125,19 @@ class ConfirmSubmissionController @Inject()(val messagesApi: MessagesApi,
       case Left(error) =>
         Logger.warn(s"[ConfirmSubmissionController][submit] Error returned from vat-returns service: $error")
         InternalServerError(views.html.errors.submission_error())
+    }
+  }
+
+  private def submitToNrs[A](periodKey: String,
+                             sessionData: SubmitVatReturnModel)(implicit user: User[A]): Future[Result] = {
+    val pageHtml: Future[Html] = renderConfirmSubmissionView(periodKey, sessionData)
+
+    pageHtml map { html =>
+      val htmlPayload = HashUtil.encode(html.body)
+      val sha256Checksum = HashUtil.getHash(html.body)
+
+      //TODO: Call NRS service (BTAT-6419)
+      Ok
     }
   }
 }

--- a/app/services/VatReturnsService.scala
+++ b/app/services/VatReturnsService.scala
@@ -35,7 +35,8 @@ class VatReturnsService @Inject()(vatReturnsConnector: VatReturnsConnector) {
     vatReturnsConnector.submitVatReturn(vrn, model)
   }
 
-  def nrsSubmission()
+  def nrsSubmission(payload: String,
+                    payloadCheckSum: String)
                    (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpGetResult[SuccessModel]] = {
 
     //TODO: BTAT-6413
@@ -64,7 +65,7 @@ class VatReturnsService @Inject()(vatReturnsConnector: VatReturnsConnector) {
       businessId = "",
       notableEvent = "",
       payloadContentType = "",
-      payloadSha256Checksum = "",
+      payloadSha256Checksum = payloadCheckSum,
       userSubmissionTimestamp = LocalDateTime.now(),
       identityData = identityDataModel,
       userAuthToken = "",
@@ -72,9 +73,6 @@ class VatReturnsService @Inject()(vatReturnsConnector: VatReturnsConnector) {
       searchKeys = SearchKeys("", ""),
       receiptData = receiptDataModel
     )
-
-    //TODO: BTAT-6415
-    val payload = ""
 
     val submissionModel = RequestModel(
       payload = payload,

--- a/app/utils/HashUtil.scala
+++ b/app/utils/HashUtil.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.Base64
+
+object HashUtil {
+
+  private val sha256 = MessageDigest.getInstance("SHA-256")
+
+  def encode(value: String): String = Base64.getEncoder.encodeToString(value.getBytes(StandardCharsets.UTF_8))
+  def getHash(value: String): String = sha256.digest(value.getBytes()).map("%02x" format _).mkString
+
+}

--- a/test/services/VatReturnsServiceSpec.scala
+++ b/test/services/VatReturnsServiceSpec.scala
@@ -90,7 +90,7 @@ class VatReturnsServiceSpec extends BaseSpec {
           .expects(*, *, *)
           .returning(Future.successful(expectedResult))
 
-        val result: HttpGetResult[SuccessModel] = await(service.nrsSubmission())
+        val result: HttpGetResult[SuccessModel] = await(service.nrsSubmission("payload", "checksum"))
 
         result shouldBe expectedResult
       }
@@ -106,7 +106,7 @@ class VatReturnsServiceSpec extends BaseSpec {
           .expects(*, *, *)
           .returning(Future.successful(expectedResult))
 
-        val result: HttpGetResult[SuccessModel] = await(service.nrsSubmission())
+        val result: HttpGetResult[SuccessModel] = await(service.nrsSubmission("payload", "checksum"))
 
         result shouldBe expectedResult
       }

--- a/test/utils/HashUtilSpec.scala
+++ b/test/utils/HashUtilSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import java.util.Base64
+
+import uk.gov.hmrc.play.test.UnitSpec
+
+class HashUtilSpec extends UnitSpec {
+
+  "Calling .encode" should {
+
+    val decodedValue = "hello"
+    val encodedValue = "aGVsbG8="
+
+    "return an encoded string version of input" in {
+      HashUtil.encode(decodedValue) shouldBe encodedValue
+    }
+  }
+
+  "Calling .getChecksum" should {
+
+    val value = "hello"
+    val checksum = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+
+    "return the hash of the input" in {
+      HashUtil.getHash(value) shouldBe checksum
+    }
+  }
+}


### PR DESCRIPTION
Slightly refactored controller to allow for reuse of view generation.
To check the methods in HashUtil actually worked I manually checked using the following: https://defuse.ca/checksums.htm#checksums
https://www.base64encode.org/

# Pull Request Checklist
* [X] Branch is rebased with master
* [X] Added Unit Tests for changed functionality
* [X] Ran `sbt clean compile coverage test it:test coverageReport`, all tests pass and coverage meets minimum
* [X] Checked libraries are up to date with `sbt validate`. (If applicable) library updates are done in a separate, single commit
* [ ] Ran [submit-vat-return-acceptance-tests](https://github.com/hmrc/submit-vat-return-acceptance-tests) (see README of repo)
* [ ] Ran [vat-returns-performance-tests](https://github.com/hmrc/vat-returns-performance-tests) (see README of repo)
* [ ] (If applicable) raised app-config-* PRs
* [ ] (If applicable) ran Wave test for changes to views
* [ ] (If applicable) added Integration Tests
