### PR TITLE
[BTAT-6417] Added default values for NRS metadata

### DIFF
--- a/app/models/nrs/Metadata.scala
+++ b/app/models/nrs/Metadata.scala
@@ -21,9 +21,9 @@ import java.time.{LocalDateTime, ZoneId}
 
 import play.api.libs.json._
 
-case class Metadata(businessId: String,
-                    notableEvent: String,
-                    payloadContentType: String,
+case class Metadata(businessId: String = "vat",
+                    notableEvent: String = "vat-return",
+                    payloadContentType: String = "text/html",
                     payloadSha256Checksum: String,
                     userSubmissionTimestamp: LocalDateTime,
                     identityData: IdentityData,

--- a/app/services/VatReturnsService.scala
+++ b/app/services/VatReturnsService.scala
@@ -16,6 +16,7 @@
 
 package services
 
+import java.net.URLDecoder
 import java.time.{LocalDateTime, ZoneOffset}
 
 import connectors.VatReturnsConnector
@@ -72,10 +73,7 @@ class VatReturnsService @Inject()(vatReturnsConnector: VatReturnsConnector) {
       identityData = identityDataModel,
       userAuthToken = "",
       headerData = headerData,
-      searchKeys = SearchKeys(
-        vrn = user.vrn,
-        periodKey = periodKey
-      ),
+      searchKeys = searchKeys(user.vrn, periodKey),
       receiptData = receiptDataModel
     )
 
@@ -86,4 +84,9 @@ class VatReturnsService @Inject()(vatReturnsConnector: VatReturnsConnector) {
 
     vatReturnsConnector.nrsSubmission(submissionModel)
   }
+
+  private[services] def searchKeys(vrn: String, periodKey: String): SearchKeys = SearchKeys(
+    vrn = vrn,
+    periodKey = URLDecoder.decode(periodKey, "UTF-8")
+  )
 }

--- a/test/assets/NrsTestData.scala
+++ b/test/assets/NrsTestData.scala
@@ -191,7 +191,7 @@ object NrsTestData {
       s"""
          |{
          |    "businessId": "vat",
-         |    "notableEvent": "vat-registration",
+         |    "notableEvent": "vat-return",
          |    "payloadContentType": "text/html",
          |    "payloadSha256Checksum": "426a1c28<snip>d6d363",
          |    "userSubmissionTimestamp": "2018-04-07T12:13:25.156Z",
@@ -261,9 +261,6 @@ object NrsTestData {
       """.stripMargin)
 
     val correctModel: Metadata = Metadata(
-      businessId = "vat",
-      notableEvent = "vat-registration",
-      payloadContentType = "text/html",
       payloadSha256Checksum = "426a1c28<snip>d6d363",
       userSubmissionTimestamp = LocalDateTime.ofInstant(Instant.parse("2018-04-07T12:13:25.156Z"), ZoneId.of("UTC")),
       identityData = IdentityDataTestData.correctModel,

--- a/test/services/VatReturnsServiceSpec.scala
+++ b/test/services/VatReturnsServiceSpec.scala
@@ -90,7 +90,7 @@ class VatReturnsServiceSpec extends BaseSpec {
           .expects(*, *, *)
           .returning(Future.successful(expectedResult))
 
-        val result: HttpGetResult[SuccessModel] = await(service.nrsSubmission("payload", "checksum"))
+        val result: HttpGetResult[SuccessModel] = await(service.nrsSubmission("18AA", "payload", "checksum")(hc, ec, user))
 
         result shouldBe expectedResult
       }
@@ -106,7 +106,7 @@ class VatReturnsServiceSpec extends BaseSpec {
           .expects(*, *, *)
           .returning(Future.successful(expectedResult))
 
-        val result: HttpGetResult[SuccessModel] = await(service.nrsSubmission("payload", "checksum"))
+        val result: HttpGetResult[SuccessModel] = await(service.nrsSubmission("18AA", "payload", "checksum")(hc, ec, user))
 
         result shouldBe expectedResult
       }

--- a/test/services/VatReturnsServiceSpec.scala
+++ b/test/services/VatReturnsServiceSpec.scala
@@ -20,7 +20,7 @@ import base.BaseSpec
 import connectors.VatReturnsConnector
 import connectors.httpParsers.ResponseHttpParsers.HttpGetResult
 import models.errors.UnexpectedJsonFormat
-import models.nrs.{RequestModel, SuccessModel}
+import models.nrs.{RequestModel, SearchKeys, SuccessModel}
 import models.vatReturnSubmission.{SubmissionModel, SubmissionSuccessModel}
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -110,6 +110,13 @@ class VatReturnsServiceSpec extends BaseSpec {
 
         result shouldBe expectedResult
       }
+    }
+  }
+
+  "Calling .searchKeys" should {
+
+    "return vrn and decoded period key in a model" in {
+      service.searchKeys("123456789", "%23001") shouldBe SearchKeys("123456789", "#001")
     }
   }
 }


### PR DESCRIPTION
The submission request body will be fully checked in integration test, its a bit difficult to test at this stage without creating a lot of chained methods returning the values in each bit of the model which is why I didn't include tests for everything. No h8
# Pull Request Checklist
* [X] Branch is rebased with master
* [ ] Added Unit Tests for changed functionality
* [X] Ran `sbt clean compile coverage test it:test coverageReport`, all tests pass and coverage meets minimum
* [X] Checked libraries are up to date with `sbt validate`. (If applicable) library updates are done in a separate, single commit
* [ ] Ran [submit-vat-return-acceptance-tests](https://github.com/hmrc/submit-vat-return-acceptance-tests) (see README of repo)
* [ ] Ran [vat-returns-performance-tests](https://github.com/hmrc/vat-returns-performance-tests) (see README of repo)
* [ ] (If applicable) raised app-config-* PRs
* [ ] (If applicable) ran Wave test for changes to views
* [ ] (If applicable) added Integration Tests
