### PR TITLE
Updated £ sign to be added by HTML instead of CSS on moneyInput helper

### DIFF
--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -34,7 +34,7 @@
   scriptElem: Option[Html] = None, user: Option[User[_]] = None)(implicit request: Request[_], messages: Messages)
 
 @linkElement = {
-    <link rel="stylesheet" type="text/css" href='@routes.Assets.at("css/submitVat.css")'>
+    <link rel="stylesheet" type="text/css" href='@routes.Assets.at("css/submitVat-v2.css")'>
 }
 
 @scriptElement = {

--- a/app/views/templates/inputs/moneyInput.scala.html
+++ b/app/views/templates/inputs/moneyInput.scala.html
@@ -15,14 +15,14 @@
  *@
 
 @(field: Field,
-        label: String,
-        labelHidden: Boolean = true,
-        decimalPlace: Boolean,
-        hint: Option[String] = None)(implicit messages: Messages)
+  label: String,
+  labelHidden: Boolean = true,
+  decimalPlace: Boolean,
+  hint: Option[String] = None)(implicit messages: Messages)
 
 <div class="form-group @if(field.hasErrors){form-field--error}">
 
-    <label for="@field.id" class="form-label @if(labelHidden) {visuallyhidden}">
+    <label for="@field.id" class="form-label @if(labelHidden){visuallyhidden}">
         @label
     </label>
 
@@ -32,13 +32,14 @@
         </span>
     }
 
-    <span class="input-currency"></span>
-
-    <input type="tel"
-    class="form-control moneyField input--no-spinner @if(field.hasErrors) {error-field}"
-    name="@field.name"
-    id="@field.id"
-    value="@field.value"
-    step="@if(decimalPlace) {0.01} else {1}"/>
+    <div class="input-icon">
+        <span>&pound;</span>
+        <input type="tel"
+            class="form-control @if(field.hasErrors){error-field}"
+            name="@field.name"
+            id="@field.id"
+            value="@field.value"
+            step="@if(decimalPlace) {0.01} else {1}"/>
+    </div>
 
 </div>

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ val compile = Seq(
   "uk.gov.hmrc" %% "bootstrap-play-25" % "4.16.0",
   "uk.gov.hmrc" %% "play-whitelist-filter" % "3.1.0-play-25",
   "uk.gov.hmrc" %% "play-language" % "3.4.0",
-  "uk.gov.hmrc" %% "auth-client" % "2.27.2-play-25",
+  "uk.gov.hmrc" %% "auth-client" % "2.28.0-play-25",
   "uk.gov.hmrc" %% "domain" % "5.6.0-play-25"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ val compile = Seq(
   "uk.gov.hmrc" %% "bootstrap-play-25" % "4.16.0",
   "uk.gov.hmrc" %% "play-whitelist-filter" % "3.1.0-play-25",
   "uk.gov.hmrc" %% "play-language" % "3.4.0",
-  "uk.gov.hmrc" %% "auth-client" % "2.27.0-play-25",
+  "uk.gov.hmrc" %% "auth-client" % "2.27.2-play-25",
   "uk.gov.hmrc" %% "domain" % "5.6.0-play-25"
 )
 

--- a/public/css/submitVat-v2.css
+++ b/public/css/submitVat-v2.css
@@ -1,0 +1,16 @@
+.input-icon {
+    position: relative;
+}
+
+.input-icon > span {
+    position: absolute;
+    transform: translate(0, -50%);
+    top: 51%;
+    width: 25px;
+    text-align: center;
+}
+
+.input-icon > input {
+    padding-left: 20px;
+    width: 100%;
+}

--- a/public/css/submitVat.css
+++ b/public/css/submitVat.css
@@ -1,5 +1,0 @@
-.moneyField {
-    padding-left: 20px;
-    text-align: left;
-    width: 100%;
-}

--- a/test/views/templates/inputs/MoneyInputTemplateSpec.scala
+++ b/test/views/templates/inputs/MoneyInputTemplateSpec.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.templates.inputs
+
+import forms.SubmitVatReturnForm
+import play.api.data.Form
+import play.api.data.Forms._
+import play.twirl.api.Html
+import views.html.templates.inputs.moneyInput
+import views.templates.TemplateBaseSpec
+
+class MoneyInputTemplateSpec extends TemplateBaseSpec {
+
+  "Calling MoneyInput" when {
+
+    case class Model(amount: Int)
+
+    val form: Form[Model] = Form(
+      mapping(
+        "amount" -> number
+      )(Model.apply)(Model.unapply)
+    ).fill(Model(3))
+
+    "field has no errors and no default arguments overridden" should {
+
+      val template = moneyInput(
+        field = form("amount"),
+        label = "label1",
+        decimalPlace = true
+      )
+
+      val expectedMarkup = formatHtml(Html(
+        s"""
+        | <div class="form-group ">
+        |   <label for="amount" class="form-label visuallyhidden">
+        |     label1
+        |   </label>
+        |   <div class="input-icon">
+        |     <span>£</span>
+        |     <input type="tel" class="form-control " name="amount" id="amount" value="3" step="0.01"/>
+        |   </div>
+        | </div>
+      """.stripMargin
+      ))
+
+      "render the correct markup" in {
+        formatHtml(template) shouldBe expectedMarkup
+      }
+    }
+
+    "field has an error" should {
+
+      val template = moneyInput(
+        field = form.withError("amount", "Error message")("amount"),
+        label = "label1",
+        decimalPlace = true
+      )
+
+      val expectedMarkup = formatHtml(Html(
+        s"""
+           | <div class="form-group form-field--error">
+           |   <label for="amount" class="form-label visuallyhidden">
+           |     label1
+           |   </label>
+           |   <div class="input-icon">
+           |     <span>£</span>
+           |     <input type="tel" class="form-control error-field" name="amount" id="amount" value="3" step="0.01"/>
+           |   </div>
+           | </div>
+      """.stripMargin
+      ))
+
+      "render the correct markup" in {
+        formatHtml(template) shouldBe expectedMarkup
+      }
+    }
+
+    "hint text is supplied" should {
+
+      val template = moneyInput(
+        field = form("amount"),
+        label = "label1",
+        decimalPlace = true,
+        hint = Some("Hint text")
+      )
+
+      val expectedMarkup = formatHtml(Html(
+        s"""
+           | <div class="form-group ">
+           |   <label for="amount" class="form-label visuallyhidden">
+           |     label1
+           |   </label>
+           |   <span class="form-hint">
+           |     Hint text
+           |   </span>
+           |   <div class="input-icon">
+           |     <span>£</span>
+           |     <input type="tel" class="form-control " name="amount" id="amount" value="3" step="0.01"/>
+           |   </div>
+           | </div>
+      """.stripMargin
+      ))
+
+      "render the correct markup" in {
+        formatHtml(template) shouldBe expectedMarkup
+      }
+    }
+
+    "label is not hidden" should {
+
+      val template = moneyInput(
+        field = form("amount"),
+        label = "label1",
+        decimalPlace = true,
+        labelHidden = false
+      )
+
+      val expectedMarkup = formatHtml(Html(
+        s"""
+           | <div class="form-group ">
+           |   <label for="amount" class="form-label ">
+           |     label1
+           |   </label>
+           |   <div class="input-icon">
+           |     <span>£</span>
+           |     <input type="tel" class="form-control " name="amount" id="amount" value="3" step="0.01"/>
+           |   </div>
+           | </div>
+      """.stripMargin
+      ))
+
+      "render the correct markup" in {
+        formatHtml(template) shouldBe expectedMarkup
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request Checklist
* [X] Branch is rebased with master
* [X] Added Unit Tests for changed functionality
* [X] Ran `sbt clean compile coverage test it:test coverageReport`, all tests pass and coverage meets minimum
* [X] Checked libraries are up to date with `sbt validate`. (If applicable) library updates are done in a separate, single commit
* [ ] Ran [submit-vat-return-acceptance-tests](https://github.com/hmrc/submit-vat-return-acceptance-tests) (see README of repo)
* [ ] Ran [vat-returns-performance-tests](https://github.com/hmrc/vat-returns-performance-tests) (see README of repo)
* [ ] (If applicable) raised app-config-* PRs
* [X] (If applicable) ran Wave test for changes to views
* [ ] (If applicable) added Integration Tests
