### PR TITLE
Removed year from submitted returns page URL

### DIFF
--- a/app/views/confirmation_view.scala.html
+++ b/app/views/confirmation_view.scala.html
@@ -27,12 +27,11 @@
     (user.session.get(SessionKeys.submissionYear), user.session.get(SessionKeys.inSessionPeriodKey)) match {
         case (Some(year), Some(periodKey)) if year.nonEmpty && periodKey.nonEmpty =>
             s"${appConfig.viewSubmittedReturnUrl}/$year/$periodKey"
-        case _ =>
-            s"${appConfig.viewSubmittedReturnUrl}/${Year.now()}"
+        case _ => appConfig.viewSubmittedReturnUrl
     }
 }
 
-@VatAccountText = @{
+@vatAccountText = @{
     if(user.isAgent) {
         messages("confirmation_view.viewClientAccount")
     } else {
@@ -42,51 +41,40 @@
 
 @main_template(messages("confirmation_view.title"), appConfig = appConfig, bodyClasses = None, user = Some(user)) {
 
-<div class="govuk-box-highlight" xmlns="http://www.w3.org/1999/html">
-    <h1 class="heading-xlarge">@messages("confirmation_view.heading")</h1>
+    <div class="govuk-box-highlight" xmlns="http://www.w3.org/1999/html">
+        <h1 class="heading-xlarge">@messages("confirmation_view.heading")</h1>
     </div>
 
     <h2>@messages("confirmation_view.subHeading")</h2>
-
     <p>@messages("confirmation_view.paragraph")</p>
 
     @if(user.isAgent) {
         <p>
-            <a
-              href="@{appConfig.changeClientUrl}?redirectUrl=@{appConfig.agentActionUrl}">@messages("confirmation_view.changeClient")</a>
+            <a href="@{appConfig.changeClientUrl}?redirectUrl=@{appConfig.agentActionUrl}">
+                @messages("confirmation_view.changeClient")
+            </a>
         </p>
     }
 
-@if(!appConfig.features.viewVatReturnEnabled()) {
-<p>
-    @helpers.form(action = controllers.routes.ConfirmationController.submit) {
-    <button
-            class="button"
-            type="submit"
-            id="submit-confirmation-finish-button">
-        @messages("common.finish")
-    </button>
-    }
-</p>
-} else {
-    <div id="displayFlex">
-        <a
-            class="button"
-            role="button"
-            id="view-vat-return-button"
-            href=@viewSubmittedReturnUrl>
-            @messages("confirmation_view.viewVATReturn")
-        </a>
+    @if(!appConfig.features.viewVatReturnEnabled()) {
+        <p>
+            @helpers.form(action = controllers.routes.ConfirmationController.submit) {
+                <button class="button" type="submit" id="submit-confirmation-finish-button">
+                    @messages("common.finish")
+                </button>
+            }
+        </p>
+    } else {
+        <div id="displayFlex">
+            <a class="button" role="button" id="view-vat-return-button" href=@viewSubmittedReturnUrl>
+                @messages("confirmation_view.viewVATReturn")
+            </a>
 
-        @helpers.form(action = controllers.routes.ConfirmationController.submit) {
-        <button
-              class="button-grey button--secondary"
-              type="submit"
-              role="button"
-              id="finish-button2">
-            @VatAccountText
-        </button>
-        }
-    </div>
+            @helpers.form(action = controllers.routes.ConfirmationController.submit) {
+                <button class="button-grey button--secondary" type="submit" role="button" id="finish-button2">
+                    @vatAccountText
+                </button>
+            }
+        </div>
     }
 }


### PR DESCRIPTION
### Merge with BTAT-7420
# Pull Request Checklist
* [X] Branch is rebased with master
* [X] Added Unit Tests for changed functionality
* [X] Ran `sbt clean compile coverage test it:test coverageReport`, all tests pass and coverage meets minimum
* [X] Checked libraries are up to date with `sbt validate`. (If applicable) library updates are done in a separate, single commit
* [X] Ran [submit-vat-return-acceptance-tests](https://github.com/hmrc/submit-vat-return-acceptance-tests) (see README of repo)
* [ ] Ran [vat-returns-performance-tests](https://github.com/hmrc/vat-returns-performance-tests) (see README of repo)
* [ ] (If applicable) raised app-config-* PRs
* [ ] (If applicable) ran Wave test for changes to views
* [ ] (If applicable) added Integration Tests
