### PR TITLE
BTAT-8819 Added insolvency check to auth predicate for principal users

### DIFF
--- a/app/common/SessionKeys.scala
+++ b/app/common/SessionKeys.scala
@@ -23,6 +23,7 @@ object SessionKeys {
   val viewModel = "mtdReturnInformation"
   val submissionYear = "submissionYear"
   val inSessionPeriodKey = "inSessionPeriodKey"
+  val insolventWithoutAccessKey: String = "insolventWithoutAccess"
 
   object HonestyDeclaration {
     val key = "mtdVatHonestyDeclaration"

--- a/app/models/CustomerDetails.scala
+++ b/app/models/CustomerDetails.scala
@@ -18,13 +18,13 @@ package models
 
 import play.api.libs.json.{Json, OFormat}
 
-case class CustomerDetails(
-                            firstName: Option[String],
-                            lastName: Option[String],
-                            tradingName: Option[String],
-                            organisationName: Option[String],
-                            hasFlatRateScheme: Boolean = false
-                          ) {
+case class CustomerDetails(firstName: Option[String],
+                           lastName: Option[String],
+                           tradingName: Option[String],
+                           organisationName: Option[String],
+                           hasFlatRateScheme: Boolean = false,
+                           isInsolvent: Boolean,
+                           continueToTrade: Option[Boolean]) {
 
   val isOrg: Boolean = organisationName.isDefined
   val isInd: Boolean = firstName.isDefined || lastName.isDefined
@@ -34,6 +34,11 @@ case class CustomerDetails(
   }
   val businessName: Option[String] = if (isOrg) organisationName else userName
   val clientName: Option[String] = if (tradingName.isDefined) tradingName else businessName
+
+  val isInsolventWithoutAccess: Boolean = continueToTrade match {
+    case Some(false) => isInsolvent
+    case _ => false
+  }
 }
 
 

--- a/it/connectors/VatSubscriptionConnectorISpec.scala
+++ b/it/connectors/VatSubscriptionConnectorISpec.scala
@@ -45,7 +45,9 @@ class VatSubscriptionConnectorISpec extends BaseISpec {
             Some("Alos"),
             Some("Blue Rathalos"),
             Some("Silver Rathalos"),
-            hasFlatRateScheme = true
+            hasFlatRateScheme = true,
+            isInsolvent = false,
+            continueToTrade = Some(true)
           )
 
           stubGet(s"/vat-subscription/$vrn/customer-details", customerInformationSuccessJson.toString(), OK)

--- a/it/pages/ConfirmSubmissionPageSpec.scala
+++ b/it/pages/ConfirmSubmissionPageSpec.scala
@@ -48,10 +48,12 @@ class ConfirmSubmissionPageSpec extends NrsAssets with GivenWhenThen {
       "due" -> "2018-03-07"
     ).toString()
 
-    val mandationStatusSessionValue = Map("mtdVatMandationStatus" -> "Non MTDfB")
-    val nineBoxSessionValue = Map("mtdNineBoxReturnData" -> nineBoxSessionData(LocalDate.now().minusDays(1).toString))
+    val mandationStatusSessionValue = Map(SessionKeys.mandationStatus -> "Non MTDfB")
+    val nineBoxSessionValue = Map(SessionKeys.returnData -> nineBoxSessionData(LocalDate.now().minusDays(1).toString))
     val honestySessionValue: String => Map[String, String] = periodKey => Map(SessionKeys.HonestyDeclaration.key -> s"$vrn-$periodKey")
-    val fullSessionValues: Map[String, String] = mandationStatusSessionValue ++ nineBoxSessionValue ++ honestySessionValue("18AA")
+    val insolvencyValue = Map(SessionKeys.insolventWithoutAccessKey -> "false")
+    val fullSessionValues: Map[String, String] =
+      mandationStatusSessionValue ++ nineBoxSessionValue ++ honestySessionValue("18AA") ++ insolvencyValue
 
     def request(sessionValues: Map[String, String] = Map.empty): WSResponse = postJson("/18AA/confirm-submission", sessionValues)
 
@@ -84,7 +86,9 @@ class ConfirmSubmissionPageSpec extends NrsAssets with GivenWhenThen {
             "lastName" -> "Name",
             "tradingName" -> "",
             "organisationName" -> "",
-            "hasFlatRateScheme" -> false
+            "hasFlatRateScheme" -> false,
+            "isInsolvent" -> false,
+            "continueToTrade" -> true
           )
 
           "NRS returns successful response and backend submission returns 200" should {

--- a/it/stubs/VatSubscriptionStub.scala
+++ b/it/stubs/VatSubscriptionStub.scala
@@ -28,7 +28,9 @@ object VatSubscriptionStub extends BaseISpec {
     "lastName" -> "Alos",
     "tradingName" -> "Blue Rathalos",
     "organisationName" -> "Silver Rathalos",
-    "hasFlatRateScheme" -> true
+    "hasFlatRateScheme" -> true,
+    "isInsolvent" -> false,
+    "continueToTrade" -> true
   )
 
   val mandationStatusSuccessJson: JsObject = Json.obj(

--- a/test/assets/CustomerDetailsTestAssets.scala
+++ b/test/assets/CustomerDetailsTestAssets.scala
@@ -17,14 +17,21 @@
 package assets
 
 import models.CustomerDetails
+import play.api.libs.json.{JsObject, Json}
 
 object CustomerDetailsTestAssets {
 
   val customerDetailsModel: CustomerDetails = CustomerDetails(
-    firstName =  Some("Duanne"),
-    lastName =  Some("MilesAndMiles"),
-    tradingName =  Some("duannetherepairman"),
-    organisationName =  Some("BadGuys")
+    firstName =  Some("Test"),
+    lastName =  Some("User"),
+    tradingName =  Some("ABC Solutions"),
+    organisationName =  Some("ABCL"),
+    isInsolvent = false,
+    continueToTrade = Some(true)
+  )
+
+  val customerDetailsModelMin: CustomerDetails = CustomerDetails(
+    None, None, None, None, hasFlatRateScheme = false, isInsolvent = false, None
   )
 
   val customerDetailsWithFRS: CustomerDetails = CustomerDetails(
@@ -32,7 +39,30 @@ object CustomerDetailsTestAssets {
     lastName = Some("User"),
     tradingName = Some("ABC Solutions"),
     organisationName = Some("ABCL"),
-    hasFlatRateScheme = true
+    hasFlatRateScheme = true,
+    isInsolvent = false,
+    None
   )
 
+  val customerDetailsInsolvent: CustomerDetails = customerDetailsModel.copy(isInsolvent = true, continueToTrade = Some(false))
+
+  val customerDetailsJson: JsObject = Json.obj(
+    "firstName" -> "Test",
+    "lastName" -> "User",
+    "tradingName" -> "ABC Solutions",
+    "organisationName" -> "ABCL",
+    "hasFlatRateScheme" -> false,
+    "isInsolvent" -> false,
+    "continueToTrade" -> true
+  )
+
+  val customerDetailsJsonMin: JsObject = Json.obj(
+    "hasFlatRateScheme" -> false,
+    "isInsolvent" -> false
+  )
+
+  val incorrectReturnJson: JsObject = Json.obj(
+    "monster" -> "Rathalos",
+    "bestWeapon" -> "Swaxe"
+  )
 }

--- a/test/base/BaseSpec.scala
+++ b/test/base/BaseSpec.scala
@@ -19,6 +19,7 @@ package base
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, Materializer}
 import auth.AuthKeys
+import common.SessionKeys
 import config.{AppConfig, ErrorHandler}
 import mocks.MockConfig
 import models.auth.User
@@ -34,7 +35,8 @@ import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.ExecutionContext
 
-trait BaseSpec extends WordSpec with Matchers with GuiceOneAppPerSuite with MockFactory with UnitSpec with BeforeAndAfterEach with Injecting {
+trait BaseSpec extends WordSpec with Matchers with GuiceOneAppPerSuite with MockFactory with UnitSpec with BeforeAndAfterEach
+  with Injecting {
 
   implicit val config: Configuration = app.configuration
 
@@ -47,9 +49,12 @@ trait BaseSpec extends WordSpec with Matchers with GuiceOneAppPerSuite with Mock
 
   lazy val errorHandler: ErrorHandler = inject[ErrorHandler]
 
-  implicit lazy val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("", "")
+  implicit lazy val fakeRequest: FakeRequest[AnyContentAsEmpty.type] =
+    FakeRequest("", "").withSession(SessionKeys.insolventWithoutAccessKey -> "false")
   lazy val fakeRequestWithClientsVRN: FakeRequest[AnyContentAsEmpty.type] =
     FakeRequest().withSession(AuthKeys.agentSessionVrn -> vrn)
+  lazy val insolventRequest: FakeRequest[AnyContentAsEmpty.type] =
+    FakeRequest().withSession(SessionKeys.insolventWithoutAccessKey -> "true")
 
   val vrn: String = "999999999"
   val arn = "ABCD12345678901"

--- a/test/connectors/httpParsers/CustomerDetailsHttpParserSpec.scala
+++ b/test/connectors/httpParsers/CustomerDetailsHttpParserSpec.scala
@@ -16,49 +16,25 @@
 
 package connectors.httpParsers
 
+import assets.CustomerDetailsTestAssets._
 import base.BaseSpec
 import connectors.httpParsers.CustomerDetailsHttpParser.CustomerDetailsReads
-import models.CustomerDetails
 import models.errors.{ServerSideError, UnexpectedJsonFormat}
 import play.api.http.Status._
-import play.api.libs.json.{JsObject, Json}
 import uk.gov.hmrc.http.HttpResponse
 
 class CustomerDetailsHttpParserSpec extends BaseSpec {
-
-  val correctReturnJson: JsObject = Json.obj(
-    "firstName" -> "Rath",
-    "lastName" -> "Alos",
-    "tradingName" -> "Azure Rathalos",
-    "organisationName" -> "Silver Rathalos",
-    "hasFlatRateScheme" -> true
-  )
-
-  val correctEmptyReturnJson: JsObject = Json.obj(
-    "hasFlatRateScheme" -> true
-  )
-
-  val incorrectReturnJson: JsObject = Json.obj(
-    "monster" -> "Rathalos",
-    "bestWeapon" -> "Swaxe"
-  )
 
   "CustomerDetailsReads" should {
     "parse the HTTP response correctly" when {
       "the returned JSON is valid" in {
         val httpResponse = HttpResponse(
           OK,
-          correctReturnJson,
+          customerDetailsJson,
           Map.empty[String,Seq[String]]
         )
 
-        val expectedResult = CustomerDetails(
-          Some("Rath"),
-          Some("Alos"),
-          Some("Azure Rathalos"),
-          Some("Silver Rathalos"),
-          hasFlatRateScheme = true
-        )
+        val expectedResult = customerDetailsModel
 
         val result = CustomerDetailsReads.read("", "", httpResponse)
 
@@ -67,17 +43,11 @@ class CustomerDetailsHttpParserSpec extends BaseSpec {
       "the returned JSON is mostly empty" in {
         val httpResponse = HttpResponse(
           OK,
-          correctEmptyReturnJson,
+          customerDetailsJsonMin,
           Map.empty[String,Seq[String]]
         )
 
-        val expectedResult = CustomerDetails(
-          None,
-          None,
-          None,
-          None,
-          hasFlatRateScheme = true
-        )
+        val expectedResult = customerDetailsModelMin
 
         val result = CustomerDetailsReads.read("", "", httpResponse)
 

--- a/test/controllers/SubmitFormControllerSpec.scala
+++ b/test/controllers/SubmitFormControllerSpec.scala
@@ -138,8 +138,9 @@ class SubmitFormControllerSpec extends BaseSpec
           lazy val requestWithSessionData = User[AnyContentAsEmpty.type]("123456789")(fakeRequest.withSession(
             SessionKeys.returnData -> nineBoxModel,
             SessionKeys.mandationStatus -> MandationStatuses.nonMTDfB,
-            SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA")
-          )
+            SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA",
+            SessionKeys.insolventWithoutAccessKey -> "false"
+          ))
 
           lazy val result: Future[Result] = {
             mockAppConfig.features.nineBoxNIProtocolContentEnabled(false)
@@ -211,7 +212,8 @@ class SubmitFormControllerSpec extends BaseSpec
             lazy val result = {
               TestSubmitFormController.show("18AA")(fakeRequest.withSession(
                 SessionKeys.mandationStatus -> MandationStatuses.nonMTDfB,
-                SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA"
+                SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA",
+                SessionKeys.insolventWithoutAccessKey -> "false"
               ))
             }
 
@@ -262,7 +264,8 @@ class SubmitFormControllerSpec extends BaseSpec
           lazy val result = {
             TestSubmitFormController.show("18AA")(fakeRequest.withSession(
               SessionKeys.mandationStatus -> MandationStatuses.nonMTDfB,
-              SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA"
+              SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA",
+              SessionKeys.insolventWithoutAccessKey -> "false"
             ))
           }
 
@@ -304,7 +307,8 @@ class SubmitFormControllerSpec extends BaseSpec
 
             lazy val result = TestSubmitFormController.show("18AA")(fakeRequest.withSession(
               SessionKeys.mandationStatus -> MandationStatuses.nonMTDfB,
-              SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA"
+              SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA",
+              SessionKeys.insolventWithoutAccessKey -> "false"
             ))
             status(result) shouldBe Status.INTERNAL_SERVER_ERROR
 
@@ -337,7 +341,8 @@ class SubmitFormControllerSpec extends BaseSpec
             "box9" -> "1234567890123"
           ).withSession(
             SessionKeys.mandationStatus -> MandationStatuses.nonMTDfB,
-            SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA"
+            SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA",
+            SessionKeys.insolventWithoutAccessKey -> "false"
           )
 
           lazy val result = {
@@ -371,7 +376,8 @@ class SubmitFormControllerSpec extends BaseSpec
             "box9" -> "1234567890123"
           ).withSession(
             SessionKeys.mandationStatus -> MandationStatuses.nonMTDfB,
-            SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA"
+            SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA",
+            SessionKeys.insolventWithoutAccessKey -> "false"
           )
 
           lazy val result = {
@@ -416,7 +422,8 @@ class SubmitFormControllerSpec extends BaseSpec
           "box9" -> "1234567890123"
         ).withSession(
           SessionKeys.mandationStatus -> MandationStatuses.nonMTDfB,
-          SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA"
+          SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA",
+          SessionKeys.insolventWithoutAccessKey -> "false"
         )
 
         lazy val result = {
@@ -444,7 +451,8 @@ class SubmitFormControllerSpec extends BaseSpec
           "box9" -> "1234567890123"
         ).withSession(
           SessionKeys.mandationStatus -> MandationStatuses.nonMTDfB,
-          SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA"
+          SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA",
+          SessionKeys.insolventWithoutAccessKey -> "false"
         )
 
         lazy val result = {
@@ -478,7 +486,8 @@ class SubmitFormControllerSpec extends BaseSpec
         "due" -> "2019-01-05"
       ).withSession(
         SessionKeys.mandationStatus -> MandationStatuses.nonMTDfB,
-        SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA"
+        SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA",
+        SessionKeys.insolventWithoutAccessKey -> "false"
       )
 
       lazy val result = {
@@ -541,7 +550,8 @@ class SubmitFormControllerSpec extends BaseSpec
           ).withSession(
             SessionKeys.mandationStatus -> MandationStatuses.nonMTDfB,
             SessionKeys.viewModel -> sessionModel,
-            SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA"
+            SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA",
+            SessionKeys.insolventWithoutAccessKey -> "false"
           )
 
           lazy val user = User("")(request)
@@ -591,7 +601,8 @@ class SubmitFormControllerSpec extends BaseSpec
           ).withSession(
             SessionKeys.mandationStatus -> MandationStatuses.nonMTDfB,
             SessionKeys.viewModel -> sessionModel,
-            SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA"
+            SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA",
+            SessionKeys.insolventWithoutAccessKey -> "false"
           )
 
           lazy val user = User("")(request)
@@ -641,7 +652,8 @@ class SubmitFormControllerSpec extends BaseSpec
           ).withSession(
             SessionKeys.mandationStatus -> MandationStatuses.nonMTDfB,
             SessionKeys.viewModel -> sessionModel,
-            SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA"
+            SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA",
+            SessionKeys.insolventWithoutAccessKey -> "false"
           )
 
           lazy val user = User("")(request)
@@ -693,7 +705,8 @@ class SubmitFormControllerSpec extends BaseSpec
           ).withSession(
             SessionKeys.mandationStatus -> MandationStatuses.nonMTDfB,
             SessionKeys.viewModel -> sessionModel,
-            SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA"
+            SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA",
+            SessionKeys.insolventWithoutAccessKey -> "false"
           )
 
           lazy val user = User("")(request)
@@ -735,7 +748,8 @@ class SubmitFormControllerSpec extends BaseSpec
           "due" -> "2019-05-12"
         ).withSession(
           SessionKeys.mandationStatus -> MandationStatuses.nonMTDfB,
-          SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA"
+          SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA",
+          SessionKeys.insolventWithoutAccessKey -> "false"
         )
 
         "a successful response is received from the service" should {

--- a/test/mocks/service/MockVatSubscriptionService.scala
+++ b/test/mocks/service/MockVatSubscriptionService.scala
@@ -16,9 +16,10 @@
 
 package mocks.service
 
-import assets.CustomerDetailsTestAssets.customerDetailsWithFRS
+import assets.CustomerDetailsTestAssets.{customerDetailsInsolvent, customerDetailsWithFRS}
 import connectors.httpParsers.ResponseHttpParsers.HttpGetResult
 import models.CustomerDetails
+import models.errors.UnknownError
 import org.scalamock.scalatest.MockFactory
 import services.VatSubscriptionService
 import uk.gov.hmrc.http.HeaderCarrier
@@ -36,6 +37,10 @@ trait MockVatSubscriptionService extends UnitSpec with MockFactory {
       .returns(response)
   }
 
-  val successCustomerInfoResponse: Future[HttpGetResult[CustomerDetails]] = Future.successful(Right(customerDetailsWithFRS))
-
+  val successCustomerInfoResponse: Future[HttpGetResult[CustomerDetails]] =
+    Future.successful(Right(customerDetailsWithFRS))
+  val customerInfoInsolventResponse: Future[HttpGetResult[CustomerDetails]] =
+    Future.successful(Right(customerDetailsInsolvent))
+  val customerInfoFailureResponse: Future[HttpGetResult[CustomerDetails]] =
+    Future.successful(Left(UnknownError))
 }

--- a/test/services/VatSubscriptionServiceSpec.scala
+++ b/test/services/VatSubscriptionServiceSpec.scala
@@ -16,9 +16,9 @@
 
 package services
 
+import assets.CustomerDetailsTestAssets.customerDetailsModel
 import base.BaseSpec
 import connectors.VatSubscriptionConnector
-import models.CustomerDetails
 import models.errors.UnexpectedJsonFormat
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -32,13 +32,7 @@ class VatSubscriptionServiceSpec extends BaseSpec {
   "getCustomerDetails" should {
     "return a CustomerDetails model" when {
       "the model is returned from the connector" in {
-        val expectedResult = CustomerDetails(
-          Some("Hiccup"),
-          Some("Toothless"),
-          Some("Rimuru Tempest"),
-          Some("Sadao Maou"),
-          hasFlatRateScheme = true
-        )
+        val expectedResult = customerDetailsModel
 
         (mockConnector.getCustomerDetails(_: String)(_: HeaderCarrier, _: ExecutionContext))
           .expects("111111111", *, *)

--- a/test/utils/ReceiptDataHelperSpec.scala
+++ b/test/utils/ReceiptDataHelperSpec.scala
@@ -168,7 +168,7 @@ class ReceiptDataHelperSpec extends BaseSpec {
 
   private def successResponse(frs: Boolean, noName: Boolean = false) = {
     Right(CustomerDetails(
-      if(noName) None else Some("Test"), if(noName) None else Some("Name"), None, None, frs
+      if(noName) None else Some("Test"), if(noName) None else Some("Name"), None, None, frs, isInsolvent = false, None
     ))
   }
 


### PR DESCRIPTION
I added the insolvency check unit test into the `authControllerChecks` function that is already being run for each controller action that has auth.

I also gave a refactor to the `CustomerDetails` tests as they were testing for every single JSON combination in an overly complex way, which I felt was unnecessary. Now it's more in line with our other services where we just test the maximum and minimum number of fields. 