### PR TITLE
Changed logging level for obligation end date BadRequest scenarios

### DIFF
--- a/app/controllers/SubmitFormController.scala
+++ b/app/controllers/SubmitFormController.scala
@@ -142,7 +142,7 @@ class SubmitFormController @Inject()(mcc: MessagesControllerComponents,
                 )).addingToSession(SessionKeys.viewModel -> Json.toJson(viewModel).toString())
 
               } else {
-                Logger.debug("[SubmitFormController][renderViewWithoutSessionData] " +
+                Logger.warn("[SubmitFormController][renderViewWithoutSessionData] " +
                   s"Obligation end date for period $periodKey has not yet passed.")
                 errorHandler.showBadRequestError
               }
@@ -234,7 +234,7 @@ class SubmitFormController @Inject()(mcc: MessagesControllerComponents,
                   .addingToSession(SessionKeys.returnData -> Json.toJson(sessionModel).toString())
                   .removingFromSession(SessionKeys.viewModel)
               } else {
-                Logger.debug(s"[SubmitFormController][submitSuccess] Obligation end date for period $periodKey has not yet passed.")
+                Logger.warn(s"[SubmitFormController][submitSuccess] Obligation end date for period $periodKey has not yet passed.")
                 errorHandler.showBadRequestError
               }
             case _ =>


### PR DESCRIPTION
We have recently been seeing this issue in live but due to the logging level being confusingly set as "Debug" here it was difficult to troubleshoot.