### PR TITLE
BTAT-9393 - Updated the nine box form to allow for £ signs when using screen reader

### DIFF
--- a/app/forms/Constraints.scala
+++ b/app/forms/Constraints.scala
@@ -43,7 +43,7 @@ object Constraints {
 
   def validBigDecimal(emptyMessage: String, invalidMessage: String): Constraint[String] = Constraint[String]("validBigDecimal") { number =>
     if(number != "") {
-      Try(BigDecimal(number)) match {
+      Try(BigDecimal(number.stripPrefix("£"))) match {
         case Success(_) => Valid
         case Failure(_) => Invalid(invalidMessage)
       }

--- a/app/forms/SubmitVatReturnForm.scala
+++ b/app/forms/SubmitVatReturnForm.scala
@@ -34,7 +34,7 @@ case class SubmitVatReturnForm ()(implicit messages: Messages){
   val minBox5Value: BigDecimal      = 0.00
   val maxBox5Value: BigDecimal      = 99999999999.99
 
-  private def toBigDecimal(boxId : Int): String => BigDecimal = (text: String) => BigDecimal.apply(text)
+  private def toBigDecimal(boxId : Int): String => BigDecimal = (text: String) => BigDecimal.apply(text.stripPrefix("£"))
   private def fromBigDecimal(boxId : Int): BigDecimal => String = (bd: BigDecimal) => bd.toString()
   private def validNumber(boxId : Int): Constraint[String] = validBigDecimal(messages("submit_form.error.emptyError", boxId),
     messages("submit_form.error.formatCheckError", boxId))

--- a/test/forms/SubmitVatReturnFormSpec.scala
+++ b/test/forms/SubmitVatReturnFormSpec.scala
@@ -40,13 +40,13 @@ class SubmitVatReturnFormSpec extends BaseSpec {
 
       val formWithValues = form.nineBoxForm.bind(
         Map(
-          "box1" -> "1.01",
-          "box2" -> "2.02",
-          "box4" -> "4.04",
-          "box6" -> "6",
-          "box7" -> "7",
-          "box8" -> "8",
-          "box9" -> "9"
+          "box1" -> "£1.01",
+          "box2" -> "£2.02",
+          "box4" -> "£4.04",
+          "box6" -> "£6",
+          "box7" -> "£7",
+          "box8" -> "£8",
+          "box9" -> "£9"
         )
       )
 


### PR DESCRIPTION
…s used

# Pull Request Checklist
* [ ] Branch is rebased with master
* [ ] Added Unit Tests for changed functionality
* [ ] Ran `sbt clean compile coverage test it:test coverageReport`, all tests pass and coverage meets minimum
* [ ] Checked libraries are up to date with `sbt validate`. (If applicable) library updates are done in a separate, single commit
* [ ] Ran [submit-vat-return-acceptance-tests](https://github.com/hmrc/submit-vat-return-acceptance-tests) (see README of repo)
* [ ] Ran [vat-returns-performance-tests](https://github.com/hmrc/vat-returns-performance-tests) (see README of repo)
* [ ] (If applicable) raised app-config-* PRs
* [ ] (If applicable) ran Wave test for changes to views
* [ ] (If applicable) added Integration Tests
