### PR TITLE
BTAT-9691 - Util added that strips pound signs, commas and full stops

### DIFF
--- a/app/forms/Constraints.scala
+++ b/app/forms/Constraints.scala
@@ -18,6 +18,7 @@ package forms
 
 import play.api.data.validation.{Constraint, Invalid, Valid}
 import scala.util.{Failure, Success, Try}
+import utils.StripCharUtil._
 
 object Constraints {
 
@@ -43,7 +44,7 @@ object Constraints {
 
   def validBigDecimal(emptyMessage: String, invalidMessage: String): Constraint[String] = Constraint[String]("validBigDecimal") { number =>
     if(number != "") {
-      Try(BigDecimal(number.stripPrefix("£"))) match {
+      Try(BigDecimal(stripAll(number,"£ , ."))) match {
         case Success(_) => Valid
         case Failure(_) => Invalid(invalidMessage)
       }

--- a/app/forms/Constraints.scala
+++ b/app/forms/Constraints.scala
@@ -44,7 +44,7 @@ object Constraints {
 
   def validBigDecimal(emptyMessage: String, invalidMessage: String): Constraint[String] = Constraint[String]("validBigDecimal") { number =>
     if(number != "") {
-      Try(BigDecimal(stripAll(number,"£ , .").replaceAll(",",""))) match {
+      Try(BigDecimal(stripAll(number,"£ , ."))) match {
         case Success(_) => Valid
         case Failure(_) => Invalid(invalidMessage)
       }

--- a/app/forms/Constraints.scala
+++ b/app/forms/Constraints.scala
@@ -44,7 +44,7 @@ object Constraints {
 
   def validBigDecimal(emptyMessage: String, invalidMessage: String): Constraint[String] = Constraint[String]("validBigDecimal") { number =>
     if(number != "") {
-      Try(BigDecimal(stripAll(number,"£ , ."))) match {
+      Try(BigDecimal(stripAll(number,"£ , .").replaceAll(",",""))) match {
         case Success(_) => Valid
         case Failure(_) => Invalid(invalidMessage)
       }

--- a/app/forms/Constraints.scala
+++ b/app/forms/Constraints.scala
@@ -44,7 +44,7 @@ object Constraints {
 
   def validBigDecimal(emptyMessage: String, invalidMessage: String): Constraint[String] = Constraint[String]("validBigDecimal") { number =>
     if(number != "") {
-      Try(BigDecimal(stripAll(number,"£ , ."))) match {
+      Try(BigDecimal(stripAll(number))) match {
         case Success(_) => Valid
         case Failure(_) => Invalid(invalidMessage)
       }

--- a/app/forms/SubmitVatReturnForm.scala
+++ b/app/forms/SubmitVatReturnForm.scala
@@ -23,6 +23,7 @@ import play.api.data.Forms._
 import play.api.data.validation.Constraint
 import play.api.data.{Form, Mapping}
 import play.api.i18n.Messages
+import utils.StripCharUtil._
 
 @Singleton
 case class SubmitVatReturnForm()(implicit messages: Messages) {
@@ -34,7 +35,7 @@ case class SubmitVatReturnForm()(implicit messages: Messages) {
   val minBox5Value: BigDecimal      = 0.00
   val maxBox5Value: BigDecimal      = 99999999999.99
 
-  private def toBigDecimal: String => BigDecimal = (text: String) => BigDecimal.apply(text.stripPrefix("£"))
+  private def toBigDecimal: String => BigDecimal = (text: String) => BigDecimal.apply(stripAll(text, "£ , ."))
   private def fromBigDecimal: BigDecimal => String = (bd: BigDecimal) => bd.toString()
   private def validNumber(boxId : Int): Constraint[String] = validBigDecimal(messages("submit_form.error.emptyError", boxId),
     messages("submit_form.error.formatCheckError", boxId))

--- a/app/forms/SubmitVatReturnForm.scala
+++ b/app/forms/SubmitVatReturnForm.scala
@@ -35,7 +35,7 @@ case class SubmitVatReturnForm()(implicit messages: Messages) {
   val minBox5Value: BigDecimal      = 0.00
   val maxBox5Value: BigDecimal      = 99999999999.99
 
-  private def toBigDecimal: String => BigDecimal = (text: String) => BigDecimal.apply(stripAll(text, "£ , ."))
+  private def toBigDecimal: String => BigDecimal = (text: String) => BigDecimal.apply(stripAll(text,"£ , ."))
   private def fromBigDecimal: BigDecimal => String = (bd: BigDecimal) => bd.toString()
   private def validNumber(boxId : Int): Constraint[String] = validBigDecimal(messages("submit_form.error.emptyError", boxId),
     messages("submit_form.error.formatCheckError", boxId))

--- a/app/forms/SubmitVatReturnForm.scala
+++ b/app/forms/SubmitVatReturnForm.scala
@@ -35,7 +35,7 @@ case class SubmitVatReturnForm()(implicit messages: Messages) {
   val minBox5Value: BigDecimal      = 0.00
   val maxBox5Value: BigDecimal      = 99999999999.99
 
-  private def toBigDecimal: String => BigDecimal = (text: String) => BigDecimal.apply(stripAll(text,"£ , ."))
+  private def toBigDecimal: String => BigDecimal = (text: String) => BigDecimal.apply(stripAll(text))
   private def fromBigDecimal: BigDecimal => String = (bd: BigDecimal) => bd.toString()
   private def validNumber(boxId : Int): Constraint[String] = validBigDecimal(messages("submit_form.error.emptyError", boxId),
     messages("submit_form.error.formatCheckError", boxId))

--- a/app/utils/StripCharUtil.scala
+++ b/app/utils/StripCharUtil.scala
@@ -18,26 +18,8 @@ package utils
 
 object StripCharUtil {
 
-  def stripAll(text: String, charactersToRemove: String): String = {
-    // scalastyle:off
-      @scala.annotation.tailrec def start(n: Int): String =
-        if (n == text.length) ""
-        else if (charactersToRemove.indexOf(text.charAt(n)) < 0) end(n, text.length)
-        else start(1 + n)
-
-      @scala.annotation.tailrec def end(a: Int, n: Int): String =
-        if (n <= a) text.substring(a, n)
-        else if (charactersToRemove.indexOf(text.charAt(n - 1)) < 0) text.substring(a, n)
-        else end(a, n - 1)
-
-      val result = start(0)
-
-    result.replaceAll(",","")
-      .replaceAll("£","").trim
+  def stripAll(text: String): String = {
+   text.trim.stripPrefix("£").replaceAll(",","").stripSuffix(".")
   }
-
-
-
-
 
 }

--- a/app/utils/StripCharUtil.scala
+++ b/app/utils/StripCharUtil.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+object StripCharUtil {
+
+  def stripAll(word: String, charactersToStrip: String): String = {
+    // scalastyle:off
+    @scala.annotation.tailrec def start(n: Int): String =
+      if (n == word.length) {""}
+      else if (charactersToStrip.indexOf(word.charAt(n)) < 0) end(n, word.length)
+      else start(1 + n)
+
+    @scala.annotation.tailrec def end(a: Int, n: Int): String =
+      if (n <= a) word.substring(a, n)
+      else if (charactersToStrip.indexOf(word.charAt(n - 1)) < 0) word.substring(a, n)
+      else end(a, n - 1)
+
+    start(0)
+  }
+
+}

--- a/app/utils/StripCharUtil.scala
+++ b/app/utils/StripCharUtil.scala
@@ -18,19 +18,26 @@ package utils
 
 object StripCharUtil {
 
-  def stripAll(word: String, charactersToStrip: String): String = {
+  def stripAll(text: String, charactersToRemove: String): String = {
     // scalastyle:off
-    @scala.annotation.tailrec def start(n: Int): String =
-      if (n == word.length) {""}
-      else if (charactersToStrip.indexOf(word.charAt(n)) < 0) end(n, word.length)
-      else start(1 + n)
+      @scala.annotation.tailrec def start(n: Int): String =
+        if (n == text.length) ""
+        else if (charactersToRemove.indexOf(text.charAt(n)) < 0) end(n, text.length)
+        else start(1 + n)
 
-    @scala.annotation.tailrec def end(a: Int, n: Int): String =
-      if (n <= a) word.substring(a, n)
-      else if (charactersToStrip.indexOf(word.charAt(n - 1)) < 0) word.substring(a, n)
-      else end(a, n - 1)
+      @scala.annotation.tailrec def end(a: Int, n: Int): String =
+        if (n <= a) text.substring(a, n)
+        else if (charactersToRemove.indexOf(text.charAt(n - 1)) < 0) text.substring(a, n)
+        else end(a, n - 1)
 
-    start(0)
+      val result = start(0)
+
+    result.replaceAll(",","")
+      .replaceAll("£","").trim
   }
+
+
+
+
 
 }

--- a/test/forms/SubmitVatReturnFormSpec.scala
+++ b/test/forms/SubmitVatReturnFormSpec.scala
@@ -43,9 +43,9 @@ class SubmitVatReturnFormSpec extends BaseSpec {
 
       val formWithValues = form.nineBoxForm.bind(
         Map(
-          "box1" -> "£1.01",
-          "box2" -> "£2.02",
-          "box4" -> "£4.04",
+          "box1" -> "£1.01,",
+          "box2" -> "£2.02.",
+          "box4" -> "£4.04,",
           "box6" -> "£6",
           "box7" -> "£7",
           "box8" -> "£8",

--- a/test/utils/StripCharUtilSpec.scala
+++ b/test/utils/StripCharUtilSpec.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import uk.gov.hmrc.play.test.UnitSpec
+import utils.StripCharUtil.stripAll
+
+class StripCharUtilSpec extends UnitSpec {
+
+  "return the expected string with no pound sign" in {
+    stripAll("£100","£") shouldBe "100"
+  }
+  "return the expected string if pound signs and commas are included" in {
+    stripAll("£100,,,","£ ,") shouldBe "100"
+  }
+  "return the expected string if pound signs, commas and a full stop is present" in {
+    stripAll("£100.56,,,...","£ , .") shouldBe "100.56"
+  }
+
+}

--- a/test/utils/StripCharUtilSpec.scala
+++ b/test/utils/StripCharUtilSpec.scala
@@ -32,8 +32,14 @@ class StripCharUtilSpec extends UnitSpec {
     "return the expected string if a pound sign is present at the start and a full stop exists at the end" in {
       stripAll("£100.56.") shouldBe "100.56"
     }
-    "return the expected the expected string if whitspaces exist" in {
+    "return the expected the expected string with leading whitespaces" in {
+      stripAll("   £100") shouldBe "100"
+    }
+    "return the expected the expected string with trailing white spaces" in {
       stripAll("£100   ") shouldBe "100"
+    }
+    "return the expected string if whitespaces, commas, pound signs and a full stop exist" in {
+      stripAll("     £100,000,000.    ") shouldBe "100000000"
     }
     "return expected string as normal if no characters or whitespaces are present" in {
       stripAll("100.56") shouldBe "100.56"

--- a/test/utils/StripCharUtilSpec.scala
+++ b/test/utils/StripCharUtilSpec.scala
@@ -22,19 +22,16 @@ import utils.StripCharUtil.stripAll
 class StripCharUtilSpec extends UnitSpec {
 
   "return the expected string with no pound sign" in {
-    stripAll("£100","£") shouldBe "100"
+    stripAll("£100") shouldBe "100"
   }
   "return the expected string if pound signs and commas are included" in {
-    stripAll("£100,,,","£ ,") shouldBe "100"
+    stripAll("£100,000,000") shouldBe "100000000"
   }
   "return the expected string if pound signs, commas and a full stop is present" in {
-    stripAll("£100.56,,,...","£ , .") shouldBe "100.56"
+    stripAll("£100.56.") shouldBe "100.56"
   }
-  "return the expected string if a pound sign is included in the middle and full stops and commas are present" in {
-    stripAll("£100£.56...,,","£ . ,") shouldBe "100.56"
-  }
-  "return the expected string when commas are present" in {
-    stripAll("£100,000,000","£") shouldBe "100000000"
+  "Nothing should change if the user enters the correct string" in {
+    stripAll("100.56") shouldBe "100.56"
   }
 
 }

--- a/test/utils/StripCharUtilSpec.scala
+++ b/test/utils/StripCharUtilSpec.scala
@@ -21,17 +21,26 @@ import utils.StripCharUtil.stripAll
 
 class StripCharUtilSpec extends UnitSpec {
 
-  "return the expected string with no pound sign" in {
-    stripAll("£100") shouldBe "100"
-  }
-  "return the expected string if pound signs and commas are included" in {
-    stripAll("£100,000,000") shouldBe "100000000"
-  }
-  "return the expected string if pound signs, commas and a full stop is present" in {
-    stripAll("£100.56.") shouldBe "100.56"
-  }
-  "Nothing should change if the user enters the correct string" in {
-    stripAll("100.56") shouldBe "100.56"
+  "The stripAll function" should {
+
+    "return the expected string with no pound sign" in {
+      stripAll("£100") shouldBe "100"
+    }
+    "return the expected string if a pound sign is present at the start and commas exist" in {
+      stripAll("£100,000,000") shouldBe "100000000"
+    }
+    "return the expected string if a pound sign is present at the start and a full stop exists at the end" in {
+      stripAll("£100.56.") shouldBe "100.56"
+    }
+    "return the expected the expected string if whitspaces exist" in {
+      stripAll("£100   ") shouldBe "100"
+    }
+    "return expected string as normal if no characters or whitespaces are present" in {
+      stripAll("100.56") shouldBe "100.56"
+    }
+
   }
 
 }
+
+

--- a/test/utils/StripCharUtilSpec.scala
+++ b/test/utils/StripCharUtilSpec.scala
@@ -30,5 +30,11 @@ class StripCharUtilSpec extends UnitSpec {
   "return the expected string if pound signs, commas and a full stop is present" in {
     stripAll("£100.56,,,...","£ , .") shouldBe "100.56"
   }
+  "return the expected string if a pound sign is included in the middle and full stops and commas are present" in {
+    stripAll("£100£.56...,,","£ . ,") shouldBe "100.56"
+  }
+  "return the expected string when commas are present" in {
+    stripAll("£100,000,000","£") shouldBe "100000000"
+  }
 
 }


### PR DESCRIPTION
# Pull Request Checklist
* [ ] Branch is rebased with master
* [ ] Added Unit Tests for changed functionality
* [ ] Ran `sbt clean compile coverage test it:test coverageReport`, all tests pass and coverage meets minimum
* [ ] Checked libraries are up to date with `sbt validate`. (If applicable) library updates are done in a separate, single commit
* [ ] Ran [submit-vat-return-acceptance-tests](https://github.com/hmrc/submit-vat-return-acceptance-tests) (see README of repo)
* [ ] Ran [vat-returns-performance-tests](https://github.com/hmrc/vat-returns-performance-tests) (see README of repo)
* [ ] (If applicable) raised app-config-* PRs
* [ ] (If applicable) ran Wave test for changes to views
* [ ] (If applicable) added Integration Tests
