### PR TITLE
BTAT-10388 Adding session key to indicate user has landed on confirmation page

### DIFF
--- a/app/common/SessionKeys.scala
+++ b/app/common/SessionKeys.scala
@@ -23,6 +23,7 @@ object SessionKeys {
   val viewModel = "mtdVatvcReturnInformation"
   val submissionYear = "mtdVatvcSubmissionYear"
   val inSessionPeriodKey = "mtdVatvcInSessionPeriodKey"
+  val submittedReturn: String = "mtdVatvcSubmittedReturn"
   val insolventWithoutAccessKey: String = "insolventWithoutAccess"
   val futureInsolvencyBlock: String = "futureInsolvencyBlock"
   val viewedDDInterrupt: String = "vatViewChangeHasViewedDDInterrupt"

--- a/app/controllers/ConfirmSubmissionController.scala
+++ b/app/controllers/ConfirmSubmissionController.scala
@@ -155,7 +155,10 @@ class ConfirmSubmissionController @Inject()(mandationStatusCheck: MandationStatu
           SuccessAuditModel(user.vrn, periodKey, user.arn),
           Some(controllers.routes.ConfirmSubmissionController.submit(periodKey).url)
         )
-        Redirect(controllers.routes.ConfirmationController.show.url).removingFromSession(SessionKeys.returnData)
+        Redirect(controllers.routes.ConfirmationController.show.url)
+          .removingFromSession(SessionKeys.returnData)
+          .addingToSession(
+            SessionKeys.submittedReturn -> "true")
       case Left(error) =>
         auditService.audit(
           FailureAuditModel(user.vrn, periodKey, user.arn, error.message),

--- a/build.sbt
+++ b/build.sbt
@@ -51,10 +51,10 @@ lazy val coverageSettings: Seq[Setting[_]] = {
 
 val compile = Seq(
   play.sbt.PlayImport.ws,
-  "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "2.0.0-play-28",
-  "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % "5.19.0",
-  "uk.gov.hmrc"       %% "play-language"              % "5.1.0-play-28",
-  "uk.gov.hmrc"       %% "domain"                     % "6.2.0-play-28",
+  "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "3.10.0-play-28",
+  "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % "5.20.0",
+  "uk.gov.hmrc"       %% "play-language"              % "5.2.0-play-28",
+  "uk.gov.hmrc"       %% "domain"                     % "8.0.0-play-28",
   "com.typesafe.play" %% "play-json-joda"             % "2.9.2"
 )
 

--- a/test/controllers/ConfirmSubmissionControllerSpec.scala
+++ b/test/controllers/ConfirmSubmissionControllerSpec.scala
@@ -241,6 +241,10 @@ class ConfirmSubmissionControllerSpec extends BaseSpec
             s"redirect to ${controllers.routes.ConfirmationController.show}" in {
               redirectLocation(result) shouldBe Some(controllers.routes.ConfirmationController.show.url)
             }
+
+            "save the submitted return session key to session" in {
+              await(result).session.get(SessionKeys.submittedReturn) shouldBe Some("true")
+            }
           }
 
           "submission to backend is unsuccessful" should {
@@ -356,6 +360,7 @@ class ConfirmSubmissionControllerSpec extends BaseSpec
       "redirect to Confirmation page" in {
         redirectLocation(result) shouldBe Some(controllers.routes.ConfirmationController.show.url)
       }
+
     }
 
     "a Left is returned from buildIdentityData" should {


### PR DESCRIPTION
# Pull Request Checklist
* [x] Branch is rebased with master
* [x] Added Unit Tests for changed functionality
* [x] Ran `sbt clean compile coverage test it:test coverageReport`, all tests pass and coverage meets minimum
* [ ] Checked libraries are up to date with `sbt validate`. (If applicable) library updates are done in a separate, single commit
* [x] Ran [submit-vat-return-acceptance-tests](https://github.com/hmrc/submit-vat-return-acceptance-tests) (see README of repo)
* [ ] Ran [vat-returns-performance-tests](https://github.com/hmrc/vat-returns-performance-tests) (see README of repo)
* [ ] (If applicable) raised app-config-* PRs
* [ ] (If applicable) ran Wave test for changes to views
* [ ] (If applicable) added Integration Tests
