### PR TITLE
BTAT-11519 Adding period dates to completion rate audit events

### DIFF
--- a/app/audit/models/journey/StartAuditModel.scala
+++ b/app/audit/models/journey/StartAuditModel.scala
@@ -22,6 +22,8 @@ import utils.JsonObjectSugar
 
 case class StartAuditModel(vrn: String,
                            periodKey: String,
+                           startDate: String,
+                           endDate: String,
                            agentReferenceNumber: Option[String]) extends ExtendedAuditModel with JsonObjectSugar {
 
   override val transactionName: String = "journey-start"
@@ -29,6 +31,8 @@ case class StartAuditModel(vrn: String,
   override val detail: JsValue = jsonObjNoNulls(
     "vrn" -> vrn,
     "periodKey" -> periodKey,
+    "periodStartDate" -> startDate,
+    "periodEndDate" -> endDate,
     "agentReferenceNumber" -> agentReferenceNumber,
     "isAgent" -> agentReferenceNumber.isDefined
   )

--- a/app/audit/models/journey/SuccessAuditModel.scala
+++ b/app/audit/models/journey/SuccessAuditModel.scala
@@ -22,6 +22,8 @@ import utils.JsonObjectSugar
 
 case class SuccessAuditModel(vrn: String,
                              periodKey: String,
+                             startDate: String,
+                             endDate: String,
                              agentReferenceNumber: Option[String]) extends ExtendedAuditModel with JsonObjectSugar {
 
   override val transactionName: String = "journey-success"
@@ -29,6 +31,8 @@ case class SuccessAuditModel(vrn: String,
   override val detail: JsValue = jsonObjNoNulls(
     "vrn" -> vrn,
     "periodKey" -> periodKey,
+    "periodStartDate" -> startDate,
+    "periodEndDate" -> endDate,
     "agentReferenceNumber" -> agentReferenceNumber,
     "isAgent" -> agentReferenceNumber.isDefined
   )

--- a/app/controllers/ConfirmSubmissionController.scala
+++ b/app/controllers/ConfirmSubmissionController.scala
@@ -151,7 +151,7 @@ class ConfirmSubmissionController @Inject()(mandationStatusCheck: MandationStatu
           Some(controllers.routes.ConfirmSubmissionController.submit(periodKey).url)
         )
         auditService.audit(
-          SuccessAuditModel(user.vrn, periodKey, user.arn),
+          SuccessAuditModel(user.vrn, periodKey, sessionData.start.toString, sessionData.end.toString, user.arn),
           Some(controllers.routes.ConfirmationController.show.url)
         )
         Redirect(controllers.routes.ConfirmationController.show.url)

--- a/test/audit/mocks/MockAuditingService.scala
+++ b/test/audit/mocks/MockAuditingService.scala
@@ -27,9 +27,7 @@ trait MockAuditingService extends MockFactory {
 
   val mockAuditService: AuditService = mock[AuditService]
 
-  def setupAuditExtendedEvent[T <: ExtendedAuditModel]: Unit = {
-    (mockAuditService.audit(_: T, _: Option[String])(_: HeaderCarrier, _: ExecutionContext))
+  def setupAuditExtendedEvent(): Unit =
+    (mockAuditService.audit(_: ExtendedAuditModel, _: Option[String])(_: HeaderCarrier, _: ExecutionContext))
       .expects(*, *, *, *)
-  }
-
 }

--- a/test/audit/models/journey/StartAuditModelSpec.scala
+++ b/test/audit/models/journey/StartAuditModelSpec.scala
@@ -28,7 +28,7 @@ class StartAuditModelSpec extends BaseSpec {
 
     "user is not an agent" should {
 
-      val model = StartAuditModel("123456789", "19AA", None)
+      val model = StartAuditModel("123456789", "19AA", "2019-01-01", "2019-02-02", None)
 
       s"have the correct transaction name of '$transactionName'" in {
         model.transactionName shouldBe transactionName
@@ -42,6 +42,8 @@ class StartAuditModelSpec extends BaseSpec {
         model.detail shouldBe Json.obj(
           "vrn" -> "123456789",
           "periodKey" -> "19AA",
+          "periodStartDate" -> "2019-01-01",
+          "periodEndDate" -> "2019-02-02",
           "isAgent" -> false
         )
       }
@@ -49,12 +51,14 @@ class StartAuditModelSpec extends BaseSpec {
 
     "user is an agent" should {
 
-      val model = StartAuditModel("123456789", "19AA", Some("XARN1234567"))
+      val model = StartAuditModel("123456789", "19AA", "2019-01-01", "2019-02-02", Some("XARN1234567"))
 
       "have the correct detail for the audit event" in {
         model.detail shouldBe Json.obj(
           "vrn" -> "123456789",
           "periodKey" -> "19AA",
+          "periodStartDate" -> "2019-01-01",
+          "periodEndDate" -> "2019-02-02",
           "agentReferenceNumber" -> "XARN1234567",
           "isAgent" -> true
         )

--- a/test/audit/models/journey/SuccessAuditModelSpec.scala
+++ b/test/audit/models/journey/SuccessAuditModelSpec.scala
@@ -28,7 +28,7 @@ class SuccessAuditModelSpec extends BaseSpec {
 
     "user is not an agent" should {
 
-      val model = SuccessAuditModel("123456789", "19AA", None)
+      val model = SuccessAuditModel("123456789", "19AA", "2019-01-01", "2019-02-02", None)
 
       s"have the correct transaction name of '$transactionName'" in {
         model.transactionName shouldBe transactionName
@@ -42,6 +42,8 @@ class SuccessAuditModelSpec extends BaseSpec {
         model.detail shouldBe Json.obj(
           "vrn" -> "123456789",
           "periodKey" -> "19AA",
+          "periodStartDate" -> "2019-01-01",
+          "periodEndDate" -> "2019-02-02",
           "isAgent" -> false
         )
       }
@@ -49,12 +51,14 @@ class SuccessAuditModelSpec extends BaseSpec {
 
     "user is an agent" should {
 
-      val model = SuccessAuditModel("123456789", "19AA", Some("XARN1234567"))
+      val model = SuccessAuditModel("123456789", "19AA", "2019-01-01", "2019-02-02", Some("XARN1234567"))
 
       "have the correct detail for the audit event" in {
         model.detail shouldBe Json.obj(
           "vrn" -> "123456789",
           "periodKey" -> "19AA",
+          "periodStartDate" -> "2019-01-01",
+          "periodEndDate" -> "2019-02-02",
           "agentReferenceNumber" -> "XARN1234567",
           "isAgent" -> true
         )

--- a/test/controllers/ConfirmSubmissionControllerSpec.scala
+++ b/test/controllers/ConfirmSubmissionControllerSpec.scala
@@ -234,9 +234,9 @@ class ConfirmSubmissionControllerSpec extends BaseSpec
               mockFullAuthResponse(Future.successful(agentFullInformationResponse))
               mockNrsSubmission(Future.successful(Right(SuccessModel("1234567890"))))()
               mockExtractReceiptData(await(successReceiptDataResponse))()
-              setupAuditExtendedEvent
-              setupAuditExtendedEvent
-              setupAuditExtendedEvent
+              setupAuditExtendedEvent()
+              setupAuditExtendedEvent()
+              setupAuditExtendedEvent()
 
               status(result) shouldBe Status.SEE_OTHER
             }
@@ -265,9 +265,9 @@ class ConfirmSubmissionControllerSpec extends BaseSpec
               mockExtractReceiptData(await(successReceiptDataResponse))()
               mockFullAuthResponse(Future.successful(agentFullInformationResponse))
               mockNrsSubmission(Future.successful(Right(SuccessModel("1234567890"))))()
-              setupAuditExtendedEvent
+              setupAuditExtendedEvent()
               mockVatReturnSubmission(Future.successful(Left(ErrorModel(INTERNAL_SERVER_ERROR, ""))))()
-              setupAuditExtendedEvent
+              setupAuditExtendedEvent()
 
               status(result) shouldBe Status.INTERNAL_SERVER_ERROR
             }
@@ -353,9 +353,9 @@ class ConfirmSubmissionControllerSpec extends BaseSpec
         mockNrsSubmission(Future.successful(Right(SuccessModel("1234567890"))))()
         mockVatReturnSubmission(Future.successful(Right(SubmissionSuccessModel("12345"))))()
         mockExtractReceiptData(await(successReceiptDataResponse))()
-        setupAuditExtendedEvent
-        setupAuditExtendedEvent
-        setupAuditExtendedEvent
+        setupAuditExtendedEvent()
+        setupAuditExtendedEvent()
+        setupAuditExtendedEvent()
 
         status(result) shouldBe Status.SEE_OTHER
       }
@@ -409,7 +409,7 @@ class ConfirmSubmissionControllerSpec extends BaseSpec
         mockFullAuthResponse(Future.successful(agentFullInformationResponse))
         mockExtractReceiptData(await(successReceiptDataResponse))()
         mockNrsSubmission(Future.successful(Left(ErrorModel(BAD_REQUEST, "error message"))))()
-        setupAuditExtendedEvent
+        setupAuditExtendedEvent()
 
         status(result) shouldBe Status.INTERNAL_SERVER_ERROR
       }

--- a/test/controllers/SubmitFormControllerSpec.scala
+++ b/test/controllers/SubmitFormControllerSpec.scala
@@ -147,7 +147,6 @@ class SubmitFormControllerSpec extends BaseSpec
 
           "return 200" in {
             mockAuthorise(mtdVatAuthorisedResponse)
-            setupAuditExtendedEvent
             setupVatSubscriptionService(vatSubscriptionResponse)
             status(result) shouldBe Status.OK
           }
@@ -176,7 +175,6 @@ class SubmitFormControllerSpec extends BaseSpec
 
           "return 200" in {
             mockAuthorise(mtdVatAuthorisedResponse)
-            setupAuditExtendedEvent
             setupVatSubscriptionService(vatSubscriptionFailureResponse)
             status(result) shouldBe Status.OK
           }
@@ -219,7 +217,7 @@ class SubmitFormControllerSpec extends BaseSpec
 
             "return 200" in {
               mockAuthorise(mtdVatAuthorisedResponse)
-              setupAuditExtendedEvent
+              setupAuditExtendedEvent()
               setupVatSubscriptionService(vatSubscriptionResponse)
               setupVatObligationsService(vatObligationsResponse)()
               mockDateHasPassed(response = true)
@@ -246,7 +244,6 @@ class SubmitFormControllerSpec extends BaseSpec
 
             "return 400" in {
               mockAuthorise(mtdVatAuthorisedResponse)
-              setupAuditExtendedEvent
               setupVatSubscriptionService(vatSubscriptionResponse)
               setupVatObligationsService(vatObligationsResponse)()
               mockDateHasPassed(response = false)
@@ -282,7 +279,6 @@ class SubmitFormControllerSpec extends BaseSpec
 
           "return a 303" in {
             mockAuthorise(mtdVatAuthorisedResponse)
-            setupAuditExtendedEvent
             setupVatSubscriptionService(vatSubscriptionResponse)
             setupVatObligationsService(badPeriodKeyObsResponse)()
             status(result) shouldBe Status.SEE_OTHER
@@ -303,7 +299,6 @@ class SubmitFormControllerSpec extends BaseSpec
               Future.successful(Left(ErrorModel(INTERNAL_SERVER_ERROR, "")))
 
             mockAuthorise(mtdVatAuthorisedResponse)
-            setupAuditExtendedEvent
             setupVatSubscriptionService(vatSubscriptionErrorResponse)
             setupVatObligationsService(vatObligationsErrorResponse)()
 
@@ -312,8 +307,8 @@ class SubmitFormControllerSpec extends BaseSpec
               SessionKeys.HonestyDeclaration.key -> s"$vrn-18AA",
               SessionKeys.insolventWithoutAccessKey -> "false"
             ))
-            status(result) shouldBe Status.INTERNAL_SERVER_ERROR
 
+            status(result) shouldBe Status.INTERNAL_SERVER_ERROR
           }
         }
       }
@@ -736,6 +731,7 @@ class SubmitFormControllerSpec extends BaseSpec
 
           "return 200" in {
             mockAuthorise(mtdVatAuthorisedResponse)
+            setupAuditExtendedEvent()
             mockDateHasPassed(response = true)
             setupVatSubscriptionService(vatSubscriptionResponse)
             setupVatObligationsService(vatObligationsResponse)()


### PR DESCRIPTION
To get the obligation dates for the start of the journey I had to move the audit firing to a different function. It's still a part of the chain that loads the same page.