### PR TITLE
BTAT-11591 Updated play-frontend-hmrc, removed domain

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,9 +46,8 @@ lazy val coverageSettings: Seq[Setting[_]] = {
 
 val compile = Seq(
   play.sbt.PlayImport.ws,
-  "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "7.3.0-play-28",
-  "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % bootstrapPlayVersion,
-  "uk.gov.hmrc"       %% "domain"                     % "8.2.0-play-28",
+  "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "7.7.0-play-28",
+  "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % bootstrapPlayVersion
 )
 
 val test = Seq(


### PR DESCRIPTION
I couldn't see any reason why this service was using `domain`